### PR TITLE
formatting and documentation

### DIFF
--- a/src/KLogger.php
+++ b/src/KLogger.php
@@ -153,12 +153,10 @@ class KLogger
             mkdir($logDirectory, self::$_defaultPermissions, true);
         }
 
-        if (file_exists($this->_logFile)) {
-            if (!is_writable($this->_logFile)) {
-                $this->_logStatus = self::OPEN_FAILED;
-                $this->_messageQueue[] = $this->_messages['writefail'];
-                return;
-            }
+        if (file_exists($this->_logFile) && !is_writable($this->_logFile)) {
+            $this->_logStatus = self::OPEN_FAILED;
+            $this->_messageQueue[] = $this->_messages['writefail'];
+            return;
         }
 
         if (($this->_fileHandle = fopen($this->_logFile, "a"))) {


### PR DESCRIPTION
An article I read recently mentioned your project as a decent logging implementation, and digging into it I saw that you wanted to use the Zend coding conventions. I went ahead and reformatted the class, added some docblock comments, and made two or three minor changes.

I'm considering (later) switching out the inbuilt log priorities for the ones in Zend_Log, since they match the syslog RFC and is compatible with a few other PHP logging frameworks, but I'll tackle that later if it still interests me in a few days. 8^)
