### PR TITLE
Explicitly set permissions for logfiles to default permissions (777)

### DIFF
--- a/src/KLogger.php
+++ b/src/KLogger.php
@@ -175,6 +175,7 @@ class KLogger
         }
 
         if (($this->_fileHandle = fopen($this->_logFilePath, 'a'))) {
+	        chmod($this->_logFilePath, self::$_defaultPermissions);
             $this->_logStatus = self::STATUS_LOG_OPEN;
             $this->_messageQueue[] = $this->_messages['opensuccess'];
         } else {


### PR DESCRIPTION
On my machine, the permissions of the logfiles that are created are very restrictive (u+rw), so explicitly set them to self::$_defaultPermissions.
