### PR TITLE
Add Args to debug statements

### DIFF
--- a/src/KLogger.php
+++ b/src/KLogger.php
@@ -198,9 +198,9 @@ class KLogger
      * @param string $line Information to log
      * @return void
      */
-    public function logDebug($line)
+    public function logDebug($line, $args=NULL)
     {
-        $this->log($line, self::DEBUG);
+        $this->log($line, self::DEBUG, $args);
     }
 
     /**
@@ -247,9 +247,9 @@ class KLogger
      * @param string $line Information to log
      * @return void
      */
-    public function logInfo($line)
+    public function logInfo($line, $args=NULL)
     {
-        $this->log($line, self::INFO);
+        $this->log($line, self::INFO, $args);
     }
 
     /**
@@ -259,9 +259,9 @@ class KLogger
      * @param string $line Information to log
      * @return void
      */
-    public function logNotice($line)
+    public function logNotice($line, $args=NULL)
     {
-        $this->log($line, self::NOTICE);
+        $this->log($line, self::NOTICE, $args);
     }
 
     /**
@@ -272,9 +272,9 @@ class KLogger
      * @param string $line Information to log
      * @return void
      */
-    public function logWarn($line)
+    public function logWarn($line, $args=NULL)
     {
-        $this->log($line, self::WARN);
+        $this->log($line, self::WARN, $args);
     }
 
     /**
@@ -284,9 +284,9 @@ class KLogger
      * @param string $line Information to log
      * @return void
      */
-    public function logError($line)
+    public function logError($line, $args=NULL)
     {
-        $this->log($line, self::ERR);
+        $this->log($line, self::ERR, $args);
     }
 
     /**
@@ -297,9 +297,9 @@ class KLogger
      * @return void
      * @deprecated Use logCrit
      */
-    public function logFatal($line)
+    public function logFatal($line, $args=NULL)
     {
-        $this->log($line, self::FATAL);
+        $this->log($line, self::FATAL, $args);
     }
 
     /**
@@ -308,9 +308,9 @@ class KLogger
      * @param string $line Information to log
      * @return void
      */
-    public function logAlert($line)
+    public function logAlert($line, $args=NULL)
     {
-        $this->log($line, self::ALERT);
+        $this->log($line, self::ALERT, $args);
     }
 
     /**
@@ -319,9 +319,9 @@ class KLogger
      * @param string $line Information to log
      * @return void
      */
-    public function logCrit($line)
+    public function logCrit($line, $args=NULL)
     {
-        $this->log($line, self::CRIT);
+        $this->log($line, self::CRIT, $args);
     }
 
     /**
@@ -330,9 +330,9 @@ class KLogger
      * @param string $line Information to log
      * @return void
      */
-    public function logEmerg($line)
+    public function logEmerg($line, $args=NULL)
     {
-        $this->log($line, self::EMERG);
+        $this->log($line, self::EMERG, $args);
     }
 
     /**
@@ -341,11 +341,17 @@ class KLogger
      * @param string  $line     Text to add to the log
      * @param integer $severity Severity level of log message (use constants)
      */
-    public function log($line, $severity)
+    public function log($line, $severity, $args = NULL)
     {
         if ($this->_severityThreshold >= $severity) {
             $status = $this->_getTimeLine($severity);
             $this->writeFreeFormLine("$status $line \n");
+            if($args)
+            {
+                $dump = print_r($args, 1);
+                $dump = preg_replace( "/\r?\n/", "\n          ", $dump );
+                $this->writeFreeFormLine("\t" . print_r($dump, 1) . "\n");
+            }
         }
     }
 


### PR DESCRIPTION
Allows args to be passed to the logging function. If args are set, it prints them underneath the current log entry, with a tab. If they arent' set, the log prints as normal.
