### PR TITLE
Bug fix for a couple issues.

### DIFF
--- a/src/KLogger.php
+++ b/src/KLogger.php
@@ -207,7 +207,7 @@ class KLogger
      */
     public function logDebug($line, $args = self::NO_ARGUMENTS)
     {
-        $this->log($line, self::DEBUG);
+        $this->log($line, self::DEBUG, $args);
     }
 
     /**

--- a/src/KLogger.php
+++ b/src/KLogger.php
@@ -140,7 +140,7 @@ class KLogger
             }
         }
 
-        if (in_array($logDirectory, self::$instances)) {
+        if (in_array($logDirectory, array_keys(self::$instances))) {
             return self::$instances[$logDirectory];
         }
 

--- a/src/KLogger.php
+++ b/src/KLogger.php
@@ -181,7 +181,7 @@ class KLogger
             return;
         }
 
-        if (($this->_fileHandle = fopen($this->_logFilePath, 'a'))) {
+        if (($this->_fileHandle = fopen($this->_logFilePath, 'a')) && is_resource($this->_fileHandle)) {
             $this->_logStatus = self::STATUS_LOG_OPEN;
             $this->_messageQueue[] = $this->_messages['opensuccess'];
         } else {


### PR DESCRIPTION
Should check for the keys of the $instances array. - Fixes #4

Args should be printed when logDebug is called - They weren't being printed before.

Finishes off the args implementation, which closes #6

Fixes the problem that the constructor was not checking if the file was a valid resource. Closes #7.