### PR TITLE
Add optional object logging to logDebug

### DIFF
--- a/src/KLogger.php
+++ b/src/KLogger.php
@@ -207,7 +207,7 @@ class KLogger
      */
     public function logDebug($line, $args = self::NO_ARGUMENTS)
     {
-        $this->log($line, self::DEBUG);
+        $this->log($line, self::DEBUG, $args);
     }
 
     /**


### PR DESCRIPTION
This is just a small change so that logDebug mirrors other log levels, and allows for an optional object argument to be dumped along with the log message.