### PR TITLE
Added ability to pass a string as a basic group

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,6 +24,7 @@ download [here](http://github.com/katzgrau/KLogger/downloads).
     $log->logInfo('Returned a million search results'); //Prints to the log file
     $log->logFatal('Oh dear.'); //Prints to the log file
     $log->logInfo('Here is an object', $obj); //Prints to the log file with a dump of the object
+    $log->logInfo('Here is a Group', 'Group name'); //Prints to the log file with a group before the message
 
 ## Goals
 

--- a/example/example.php
+++ b/example/example.php
@@ -6,6 +6,7 @@ require dirname(__FILE__) . '/../src/KLogger.php';
 $log   = KLogger::instance(dirname(__FILE__), KLogger::DEBUG);
 $args1 = array('a' => array('b' => 'c'), 'd');
 $args2 = NULL;
+$args3 = 'Group1';
 
 $log->logInfo('Info Test');
 $log->logNotice('Notice Test');
@@ -18,3 +19,5 @@ $log->logEmerg('Emerg Test');
 
 $log->logInfo('Testing passing an array or object', $args1);
 $log->logWarn('Testing passing a NULL value', $args2);
+
+$log->logInfo('Testing with an additional log group as a string', $args3);

--- a/src/KLogger.php
+++ b/src/KLogger.php
@@ -58,7 +58,12 @@ class KLogger
      * print out objects etc. But we can't use NULL, 0, FALSE, etc, because those
      * are often the values the developers will test for. So we'll make one up.
      */
-    const NO_ARGUMENTS = 'KLogger::NO_ARGUMENTS';
+    const NO_ARGUMENTS          = 'KLogger::NO_ARGUMENTS';
+
+    /**
+     * Seperator used between log severity and message in the logs
+     */
+    const SEPERATOR             = '-->';
 
     /**
      * Current status of the log file
@@ -353,11 +358,28 @@ class KLogger
         if ($this->_severityThreshold >= $severity) {
             $status = $this->_getTimeLine($severity);
             
-            $line = "$status $line";
-            
             if($args !== self::NO_ARGUMENTS) {
-                /* Print the passed object value */
-                $line = $line . '; ' . var_export($args, true);
+                if (is_array($args) || is_object($args))
+                {
+                    $line = "$status $line";
+                    /* Print the passed object value */
+                    $line = $line . '; ' . var_export($args, true);
+                }
+                else
+                {
+                    if ($args)
+                    {
+                        $line = "$status " . $args . ' ' . self::SEPERATOR . " $line";
+                    }
+                    else
+                    {
+                        $line = "$status $line";
+                    }
+                }
+            }
+            else
+            {
+                $line = "$status $line";
             }
             
             $this->writeFreeFormLine($line . PHP_EOL);
@@ -386,25 +408,25 @@ class KLogger
 
         switch ($level) {
             case self::EMERG:
-                return "$time - EMERG -->";
+                return "$time - EMERG ".self::SEPERATOR;
             case self::ALERT:
-                return "$time - ALERT -->";
+                return "$time - ALERT ".self::SEPERATOR;
             case self::CRIT:
-                return "$time - CRIT -->";
+                return "$time - CRIT ".self::SEPERATOR;
             case self::FATAL: # FATAL is an alias of CRIT
-                return "$time - FATAL -->";
+                return "$time - FATAL ".self::SEPERATOR;
             case self::NOTICE:
-                return "$time - NOTICE -->";
+                return "$time - NOTICE ".self::SEPERATOR;
             case self::INFO:
-                return "$time - INFO -->";
+                return "$time - INFO ".self::SEPERATOR;
             case self::WARN:
-                return "$time - WARN -->";
+                return "$time - WARN ".self::SEPERATOR;
             case self::DEBUG:
-                return "$time - DEBUG -->";
+                return "$time - DEBUG ".self::SEPERATOR;
             case self::ERR:
-                return "$time - ERROR -->";
+                return "$time - ERROR ".self::SEPERATOR;
             default:
-                return "$time - LOG -->";
+                return "$time - LOG ".self::SEPERATOR;
         }
     }
 }

--- a/src/KLogger.php
+++ b/src/KLogger.php
@@ -408,25 +408,25 @@ class KLogger
 
         switch ($level) {
             case self::EMERG:
-                return "$time - EMERG ".self::SEPERATOR;
+                return "$time - EMERG "  . self::SEPERATOR;
             case self::ALERT:
-                return "$time - ALERT ".self::SEPERATOR;
+                return "$time - ALERT "  . self::SEPERATOR;
             case self::CRIT:
-                return "$time - CRIT ".self::SEPERATOR;
+                return "$time - CRIT "   . self::SEPERATOR;
             case self::FATAL: # FATAL is an alias of CRIT
-                return "$time - FATAL ".self::SEPERATOR;
-            case self::NOTICE:
-                return "$time - NOTICE ".self::SEPERATOR;
+                return "$time - FATAL "  . self::SEPERATOR;
+            case self::NOTICE: 
+                return "$time - NOTICE " . self::SEPERATOR;
             case self::INFO:
-                return "$time - INFO ".self::SEPERATOR;
+                return "$time - INFO "   . self::SEPERATOR;
             case self::WARN:
-                return "$time - WARN ".self::SEPERATOR;
+                return "$time - WARN "   . self::SEPERATOR;
             case self::DEBUG:
-                return "$time - DEBUG ".self::SEPERATOR;
+                return "$time - DEBUG "  . self::SEPERATOR;
             case self::ERR:
-                return "$time - ERROR ".self::SEPERATOR;
+                return "$time - ERROR "  . self::SEPERATOR;
             default:
-                return "$time - LOG ".self::SEPERATOR;
+                return "$time - LOG "    . self::SEPERATOR;
         }
     }
 }


### PR DESCRIPTION
`$log->logInfo('Testing with an additional log group as a string', 'Group Name');`
2013-05-14 20:49:44 - INFO --> Group1 --> Testing with an additional log group as a string

This pull request also adds a const to define the seperator, defaults to '-->'