### PR TITLE
Added ability to save log files for each severity type separately

### DIFF
--- a/src/KLogger.php
+++ b/src/KLogger.php
@@ -167,8 +167,9 @@ class KLogger
         $this->_logFilePath = $logDirectory
             . DIRECTORY_SEPARATOR
             . 'log_'
+            . strtolower($this->_getErrorSeverity($severity)) .'_'
             . date('Y-m-d')
-            . '.txt';
+            . '.log';
 
         $this->_severityThreshold = $severity;
         if (!file_exists($logDirectory)) {
@@ -407,4 +408,18 @@ class KLogger
                 return "$time - LOG -->";
         }
     }
+
+    /**
+     * Get error severity of a value / constant's name
+     * @param integer $value 
+     * @return string
+     */
+    private static function _getErrorSeverity($value)
+    {
+        $class = new ReflectionClass('KLogger');
+        $constants = $class->getConstants();
+        $constants = array_flip($constants);
+        return $constants[$value];
+    }
+    
 }


### PR DESCRIPTION
- added ability to save log files for each severity type separately. very useful and easier to track.
- changed log file extension from .txt to .log

examples: 
log_info_2013-12-05.log
log_debug_2013-12-05.log
log_err_2013-12-05.log
log_warn_2013-12-05.log