### PR TITLE
Add support for writing log entries to php://stdout instead of a file

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -117,19 +117,25 @@ class Logger extends AbstractLogger
             mkdir($logDirectory, $this->defaultPermissions, true);
         }
 
-        // Check for a set filename. In that case ignore prefix and extension
-        if ($this->options['filename']) {
-            $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['filename'];
+        if($logDirectory === "php://stdout") {
+            $this->logFilePath = $logDirectory;
+            $this->fileHandle  = fopen($this->logFilePath, 'w+');
         } else {
-            $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['prefix'].date('Y-m-d').'.'.$this->options['extension'];
+            if ($this->options['filename']) {
+                $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['filename'];
+            } else {
+                $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['prefix'].date('Y-m-d').'.'.$this->options['extension'];
+            }
+
+            if(file_exists($this->logFilePath) && !is_writable($this->logFilePath)) {
+                throw new RuntimeException('The file could not be written to. Check that appropriate permissions have been set.');
+            }
+            $this->fileHandle = fopen($this->logFilePath, 'a');
+            if(!$this->fileHandle) {
+                throw new RuntimeException('The file could not be opened. Check permissions.');
+            }
         }
 
-
-        if (file_exists($this->logFilePath) && !is_writable($this->logFilePath)) {
-            throw new RuntimeException('The file could not be written to. Check that appropriate permissions have been set.');
-        }
-
-        $this->fileHandle = fopen($this->logFilePath, 'a');
         if ( ! $this->fileHandle) {
             throw new RuntimeException('The file could not be opened. Check permissions.');
         }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -117,7 +117,7 @@ class Logger extends AbstractLogger
             mkdir($logDirectory, $this->defaultPermissions, true);
         }
 
-        if($logDirectory === "php://stdout") {
+        if($logDirectory === "php://stdout" || $logDirectory === "php://output") {
             $this->logFilePath = $logDirectory;
             $this->fileHandle  = fopen($this->logFilePath, 'w+');
         } else {


### PR DESCRIPTION
See issue #34 for earlier discussions regarding this. Considering the new version of KLogger I waited with submitting the PR until then.

Ideally, I would like to add the option to write to both file and stdout simultaneously but this will require more drastic changes. @katzgrau would you be ok with allowing support for outputting to stdout and file simultaneously or would you prefer not to support this? 