### PR TITLE
Fix read me and composer instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,7 @@ If you need a logger that supports PHP < 5.3, see [past releases](https://github
 From the Command Line:
 
 ```
-composer require katzgrau/klogger:1.0.*
+composer require katzgrau/klogger:dev-master
 ```
 
 In your `composer.json`:
@@ -26,7 +26,7 @@ In your `composer.json`:
 ``` json
 {
     "require": {
-        "katzgrau/klogger": "1.0.*"
+        "katzgrau/klogger": "dev-master"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "katzgrau/klogger",
-    "version": "1.0.0",
+    "version": "dev-master",
     "description": "A Simple Logging Class",
     "keywords": ["logging"],
     "require": {


### PR DESCRIPTION
PR based on issue: https://github.com/katzgrau/KLogger/issues/49 & https://github.com/katzgrau/KLogger/issues/48 & https://github.com/katzgrau/KLogger/issues/46

Changing the composer installation version to dev-master in readme.md and Composer.json in order to pull the latest changes in. 

@katzgrau You could reject this PR if version 1.0.0 would actually pull in the latest changes. It seems that https://github.com/katzgrau/KLogger/commit/46cdd92a9b4a8443120cc955bf831450cb274813 has screwed up your version as that branch is tagged with 1.0.0 but does not contain the latest changes you made recently. 