### PR TITLE
Clean constructor

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -118,7 +118,7 @@ class Logger extends AbstractLogger
         }
 
         if($logDirectory === "php://stdout" || $logDirectory === "php://output") {
-            $this->logFilePath = $logDirectory;
+            $this->setLogToStdOut($logDirectory);
             $this->setFileHandle('w+');
         } else {
             if ($this->options['filename']) {
@@ -139,6 +139,13 @@ class Logger extends AbstractLogger
         if ( ! $this->fileHandle) {
             throw new RuntimeException('The file could not be opened. Check permissions.');
         }
+    }
+
+    /**
+     * @param string $stdOutPath
+     */
+    public function setLogToStdOut($stdOutPath) {
+        $this->logFilePath = $stdOutPath;
     }
 
     /**

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -119,7 +119,7 @@ class Logger extends AbstractLogger
 
         if($logDirectory === "php://stdout" || $logDirectory === "php://output") {
             $this->logFilePath = $logDirectory;
-            $this->fileHandle  = fopen($this->logFilePath, 'w+');
+            $this->setFileHandle('w+');
         } else {
             if ($this->options['filename']) {
                 $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['filename'];
@@ -130,7 +130,7 @@ class Logger extends AbstractLogger
             if(file_exists($this->logFilePath) && !is_writable($this->logFilePath)) {
                 throw new RuntimeException('The file could not be written to. Check that appropriate permissions have been set.');
             }
-            $this->fileHandle = fopen($this->logFilePath, 'a');
+            $this->setFileHandle('a');
             if(!$this->fileHandle) {
                 throw new RuntimeException('The file could not be opened. Check permissions.');
             }
@@ -140,6 +140,16 @@ class Logger extends AbstractLogger
             throw new RuntimeException('The file could not be opened. Check permissions.');
         }
     }
+
+    /**
+     * @param $writeMode
+     *
+     * @internal param resource $fileHandle
+     */
+    public function setFileHandle($writeMode) {
+        $this->fileHandle = fopen($this->logFilePath, $writeMode);
+    }
+
 
     /**
      * Class destructor

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -112,7 +112,7 @@ class Logger extends AbstractLogger
         $this->logLevelThreshold = $logLevelThreshold;
         $this->options = array_merge($this->options, $options);
 
-        $logDirectory = rtrim($logDirectory, '\\/');
+        $logDirectory = rtrim($logDirectory, DIRECTORY_SEPARATOR);
         if ( ! file_exists($logDirectory)) {
             mkdir($logDirectory, $this->defaultPermissions, true);
         }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -113,7 +113,7 @@ class Logger extends AbstractLogger
         $this->options = array_merge($this->options, $options);
 
         $logDirectory = rtrim($logDirectory, '\\/');
-        if (! file_exists($logDirectory)) {
+        if ( ! file_exists($logDirectory)) {
             mkdir($logDirectory, $this->defaultPermissions, true);
         }
 

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -121,12 +121,7 @@ class Logger extends AbstractLogger
             $this->setLogToStdOut($logDirectory);
             $this->setFileHandle('w+');
         } else {
-            if ($this->options['filename']) {
-                $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['filename'];
-            } else {
-                $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['prefix'].date('Y-m-d').'.'.$this->options['extension'];
-            }
-
+            $this->setLogFilePath($logDirectory);
             if(file_exists($this->logFilePath) && !is_writable($this->logFilePath)) {
                 throw new RuntimeException('The file could not be written to. Check that appropriate permissions have been set.');
             }
@@ -146,6 +141,22 @@ class Logger extends AbstractLogger
      */
     public function setLogToStdOut($stdOutPath) {
         $this->logFilePath = $stdOutPath;
+    }
+
+    /**
+     * @param string $logDirectory
+     */
+    public function setLogFilePath($logDirectory) {
+        if ($this->options['filename']) {
+            if (strpos($this->options['filename'], '.log') !== false || strpos($this->options['filename'], '.txt') !== false) {
+                $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['filename'];
+            }
+            else {
+                $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['filename'].'.'.$this->options['extension'];
+            }
+        } else {
+            $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['prefix'].date('Y-m-d').'.'.$this->options['extension'];
+        }
     }
 
     /**

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -126,9 +126,6 @@ class Logger extends AbstractLogger
                 throw new RuntimeException('The file could not be written to. Check that appropriate permissions have been set.');
             }
             $this->setFileHandle('a');
-            if(!$this->fileHandle) {
-                throw new RuntimeException('The file could not be opened. Check permissions.');
-            }
         }
 
         if ( ! $this->fileHandle) {


### PR DESCRIPTION
Fixes issue: https://github.com/katzgrau/KLogger/issues/50

Also took the chance to cleanup the constructor a little bit as it has gotten a bit messy lately. 
* Moving logging to StdOut to it's own setter
* Moving setting of FileHandle to it's own setter
* Moving the setting of regular filePaths to it's own setter
    * Adding logic to search filename for .log or .txt extension. 
    If not provided, the extension as provided in $this->options is added. 
* Changing rtrim '\\\/' to DIRECTORY_SEPARATOR