### PR TITLE
Added support for custom log line format and JSON output

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -135,7 +135,50 @@ Here's the full list:
 | filename | [prefix][date].[extension] | Set the filename for the log file. **This overrides the prefix and extention options.** |
 | flushFrequency | `false` (disabled) | How many lines to flush the output buffer after |
 | prefix  | 'log_' | The log file prefix |
+| logFormat | `false` | Format of log entries |
+| appendContext | `true` | When `false`, don't append context to log entries |
 
+### Log Formatting
+
+The `logFormat` option lets you define what each line should look like and can contain parameters representing the date, message, etc.
+
+When a string is provided, it will be parsed for variables wrapped in braces (`{` and `}`) and replace them with the appropriate value:
+
+| Parameter | Description |
+| --------- | ----------- |
+| date | Current date (uses `dateFormat` option) |
+| level | The PSR log level |
+| message | The message being logged |
+| context | JSON-encoded context |
+
+#### Tab-separated
+
+Same as default format but separates parts with tabs rather than spaces:
+
+    $logFormat = "[{date}]\t[{level}]\t{message}";
+
+#### Custom variables and static text
+
+Inject custom content into log messages:
+
+    $logFormat = "[{date}] [$var] StaticText {message}";
+
+#### JSON
+
+To output pure JSON, set `appendContext` to `false` and provide something like the below as the value of the `logFormat` option:
+
+```
+$logFormat = json_encode([
+    'datetime' => '{date}',
+    'logLevel' => '{level}',
+    'message'  => '{message}',
+    'context'  => '{context}',
+]);
+```
+
+The output will look like:
+
+    {"datetime":"2015-04-16 10:28:41.186728","logLevel":"INFO","message":"Message content","context":"{"1":"foo","2":"bar"}"}
 
 ## Why use KLogger?
 

--- a/README.markdown
+++ b/README.markdown
@@ -148,6 +148,7 @@ When a string is provided, it will be parsed for variables wrapped in braces (`{
 | --------- | ----------- |
 | date | Current date (uses `dateFormat` option) |
 | level | The PSR log level |
+| priority | Integer value for log level (see `$logLevels`) |
 | message | The message being logged |
 | context | JSON-encoded context |
 

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -269,10 +269,11 @@ class Logger extends AbstractLogger
     {
         if ($this->options['logFormat']) {
             $parts = array(
-                'date'    => $this->getTimestamp(),
-                'level'   => strtoupper($level),
-                'message' => $message,
-                'context' => json_encode($context),
+                'date'     => $this->getTimestamp(),
+                'level'    => strtoupper($level),
+                'priority' => $this->logLevels[$level],
+                'message'  => $message,
+                'context'  => json_encode($context),
             );
             $message = $this->options['logFormat'];
             foreach ($parts as $part => $value) {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -268,12 +268,12 @@ class Logger extends AbstractLogger
     private function formatMessage($level, $message, $context)
     {
         if ($this->options['logFormat']) {
-            $parts = [
+            $parts = array(
                 'date'    => $this->getTimestamp(),
                 'level'   => strtoupper($level),
                 'message' => $message,
                 'context' => json_encode($context),
-            ];
+            );
             $message = $this->options['logFormat'];
             foreach ($parts as $part => $value) {
                 $message = str_replace('{'.$part.'}', $value, $message);


### PR DESCRIPTION
https://github.com/katzgrau/KLogger/issues/39

1. Custom Formatting

Accomplished with the `logFormat` option which accepts a parametized string (see readme).

2. JSON output

The option `appendContext` was added which, when set to false, allows pure JSON output via the `logFormat` option (again, see readme).