### PR TITLE
Enabled all php://xxxxxx targets

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -119,7 +119,7 @@ class Logger extends AbstractLogger
             mkdir($logDirectory, $this->defaultPermissions, true);
         }
 
-        if($logDirectory === "php://stdout" || $logDirectory === "php://output") {
+        if(strpos($logDirectory, 'php://') === 0) {
             $this->setLogToStdOut($logDirectory);
             $this->setFileHandle('w+');
         } else {


### PR DESCRIPTION
This tweak allows users to make use of php://stderr and other such destinations. Without, trying to target STDERR will err when attempting to create the handle.