### PR TITLE
Relax visibility on some private elements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "katzgrau/klogger",
+    "name": "tesladethray/klogger",
     "version": "dev-master",
-    "description": "A Simple Logging Class",
+    "description": "A (tweaked) Simple Logging Class",
     "keywords": ["logging"],
     "require": {
         "php": ">=5.3",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "tesladethray/klogger",
+    "name": "katzgrau/klogger",
     "version": "dev-master",
-    "description": "A (tweaked) Simple Logging Class",
+    "description": "A Simple Logging Class",
     "keywords": ["logging"],
     "require": {
         "php": ">=5.3",

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -20,7 +20,7 @@ use Psr\Log\LogLevel;
  * @author  Kenny Katzgrau <katzgrau@gmail.com>
  * @since   July 26, 2008
  * @link    https://github.com/katzgrau/KLogger
- * @version 1.0.0
+ * @version 1.0.1
  */
 
 /**

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -20,7 +20,7 @@ use Psr\Log\LogLevel;
  * @author  Kenny Katzgrau <katzgrau@gmail.com>
  * @since   July 26, 2008
  * @link    https://github.com/katzgrau/KLogger
- * @version 1.0.1
+ * @version 1.0.2
  */
 
 /**
@@ -37,7 +37,7 @@ class Logger extends AbstractLogger
      *
      * @var array
      */
-    private $options = array (
+    protected $options = array (
         'extension'      => 'txt',
         'dateFormat'     => 'Y-m-d G:i:s.u',
         'filename'       => false,
@@ -265,7 +265,7 @@ class Logger extends AbstractLogger
      * @param  array  $context The context
      * @return string
      */
-    private function formatMessage($level, $message, $context)
+    protected function formatMessage($level, $message, $context)
     {
         if ($this->options['logFormat']) {
             $parts = array(
@@ -316,7 +316,7 @@ class Logger extends AbstractLogger
      * @param  array $context The Context
      * @return string
      */
-    private function contextToString($context)
+    protected function contextToString($context)
     {
         $export = '';
         foreach ($context as $key => $value) {
@@ -342,7 +342,7 @@ class Logger extends AbstractLogger
      * @param  string $indent What to use as the indent.
      * @return string
      */
-    private function indent($string, $indent = '    ')
+    protected function indent($string, $indent = '    ')
     {
         return $indent.str_replace("\n", "\n".$indent, $string);
     }


### PR DESCRIPTION
I've been using the logger by making it the parent of the an adapter class. However, I've had to do [some hacky crap](https://github.com/pantheon-systems/cli/blob/646f6ef09b679af51cc39b7c9d7e7d920d0cd425/php/Terminus/Loggers/Logger.php) to extract `$options` and had copy-paste a few functions in order to get it working, though.

I would like you to consider adopting the protected visibility status for some of these elements.