### PR TITLE
Allow newer versions of psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["logging"],
     "require": {
         "php": ">=5.3",
-        "psr/log": "1.0.0"
+        "psr/log": "^1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.*"


### PR DESCRIPTION
PSR/log is currently at 1.0.2, but this package explicitly depends on 1.0.0, preventing any newer versions form being pulled in.  This PR opens up the versioning to allow any 1.0 version of psr/log to be used. 
