### PR TITLE
Fix endless loop in test

### DIFF
--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -71,7 +71,8 @@ class LoggerTest extends PHPUnit_Framework_TestCase
             fseek($fp, $pos, SEEK_END);
             $t = fgetc($fp);
             $pos = $pos - 1;
-            if ($size + $pos < 1) {
+            if ($size + $pos < -1) {
+                rewind($fp);
                 break;
             }
         }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -62,6 +62,7 @@ class LoggerTest extends PHPUnit_Framework_TestCase
 
     private function getLastLine($filename)
     {
+        $size = filesize($filename);
         $fp = fopen($filename, 'r');
         $pos = -2; // start from second to last char
         $t = ' ';
@@ -70,6 +71,9 @@ class LoggerTest extends PHPUnit_Framework_TestCase
             fseek($fp, $pos, SEEK_END);
             $t = fgetc($fp);
             $pos = $pos - 1;
+            if ($size + $pos < 1) {
+                break;
+            }
         }
 
         $t = fgets($fp);


### PR DESCRIPTION
When I tried the unit tests, they were running forever without completing. This appears to be a bug in the getLastLine function.

I believe it's due to the log files having only 1 line. If you start at end-2 and seek backwards, you won't run into another newline character.

I'm proposing to check the size of the log file, and end the loop if it tries to go beyond the beginning of the file. I confirmed that the unit tests all pass with this change.