### PR TITLE
Set log file default permissions

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -124,6 +124,10 @@ class Logger extends AbstractLogger
             $this->setFileHandle('w+');
         } else {
             $this->setLogFilePath($logDirectory);
+            if(!file_exists($this->logFilePath) || !is_writable($this->logFilePath)) {
+            	touch($this->logFilePath);
+            	chmod($this->logFilePath, $this->defaultPermissions);
+            }
             if(file_exists($this->logFilePath) && !is_writable($this->logFilePath)) {
                 throw new RuntimeException('The file could not be written to. Check that appropriate permissions have been set.');
             }


### PR DESCRIPTION
This should fix problem with log file permissions mentioned here https://github.com/katzgrau/KLogger/issues/94

I had problem with logging from user frontend (run by apache user) and cli (run by different unix user).

Mine solution checks file existence first and if it is writable, if not new file is created and chmoded to default permission (same as for log directory)