### PR TITLE
Cast explicitly originalTime to int to avoid warnings in PHP 8.1

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -305,7 +305,7 @@ class Logger extends AbstractLogger
     {
         $originalTime = microtime(true);
         $micro = sprintf("%06d", ($originalTime - floor($originalTime)) * 1000000);
-        $date = new DateTime(date('Y-m-d H:i:s.'.$micro, $originalTime));
+        $date = new DateTime(date('Y-m-d H:i:s.'.$micro, (int)$originalTime));
 
         return $date->format($this->options['dateFormat']);
     }


### PR DESCRIPTION
I ran tests on PHPUnit 9.5.*. Reverted the change (composer.json, LoggerTest) because it'd cause incompatibility with PHP 5.3 which is required version.